### PR TITLE
Fix user rendering issue and change user bar rendering

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "jwt-decode": "^2.2.0",
     "lodash": "^4.17.15",
     "node-sass": "^4.13.0",
+    "rc-progress": "^2.5.2",
     "react": "^16.10.2",
     "react-dom": "^16.10.2",
     "react-redux": "^7.1.1",

--- a/frontend/src/components/main/top_bar/top_bar_user_menu.jsx
+++ b/frontend/src/components/main/top_bar/top_bar_user_menu.jsx
@@ -30,9 +30,9 @@ export default (props) => {
             </Link>
           </li>
           <li>
-            <button onClick={ () => dispatch(logout()) } className="user-menu-link">
+            <Link to='/sign-out' onClick={ () => dispatch(logout()) } className="user-menu-link">
               Sign Out
-            </button>
+            </Link>
           </li>
         </ul>
       ) : (

--- a/frontend/src/components/main/user/user_detail.jsx
+++ b/frontend/src/components/main/user/user_detail.jsx
@@ -4,7 +4,11 @@ import {
   useSelector
 } from 'react-redux';
 import { requestUser } from '../../../actions/user_actions';
-import ProgressBar from './progress_bar';
+//import ProgressBar from './progress_bar';
+import { Line } from 'rc-progress';
+
+import '../../../stylesheets/user.scss';
+
 
 export default (props) => {
   const dispatch = useDispatch();
@@ -22,21 +26,33 @@ export default (props) => {
 
   return (
     <React.Fragment>
-      { currentUser && currentUser.health ? (
+      { currentUser && currentUser.hp ? (
         <div className="user-detail-container">
           <ul className="user-stats-ul">
             <li className="user-stats-li user-detail-username-li">
+              <s>Username:</s>
               <h3>{ currentUser.username }</h3>
-              <div>
-                {/* lowest user level is 1, user level is determined by exp */}
-                <span>Level { Math.floor((currentUser.exp + 100) / 100) }</span>
-              </div>
+            </li>
+            <li>
+              {/* lowest user level is 1, user level is determined by exp */}
+              <s>Level: </s>
+              <h4>{ Math.floor((currentUser.experience + 50) / 50) }</h4>
             </li>
             <li className="user-stats-li">
-              <ProgressBar percentage={ currentUser.hp } type='hp' />
+              <Line
+                percent={ currentUser.hp }
+                strokeColor='#a04946'
+                className="health-bar"
+              />
+              <span>{ `${ currentUser.hp } / 100` }</span>
             </li>
             <li className="user-stats-li">
-              <ProgressBar percentage={ currentUser.exp % 100 } type='exp' />
+              <Line
+                percent={ ((currentUser.experience + 50) % 50) * 2 }
+                strokeColor='#4946a0'
+                className="experience-bar"
+              />
+              <span>{ `${ currentUser.experience } / 50` }</span>
             </li>
           </ul>
         </div>

--- a/frontend/src/components/main/user/user_detail.jsx
+++ b/frontend/src/components/main/user/user_detail.jsx
@@ -33,7 +33,7 @@ export default (props) => {
               <s>Username:</s>
               <h3>{ currentUser.username }</h3>
             </li>
-            <li>
+            <li className="user-stats-li">
               {/* lowest user level is 1, user level is determined by exp */}
               <s>Level: </s>
               <h4>{ Math.floor((currentUser.experience + 50) / 50) }</h4>

--- a/frontend/src/stylesheets/main_container.scss
+++ b/frontend/src/stylesheets/main_container.scss
@@ -4,3 +4,4 @@
   height: 100%;
   background-color: $background;
 }
+

--- a/frontend/src/stylesheets/user.scss
+++ b/frontend/src/stylesheets/user.scss
@@ -1,0 +1,29 @@
+@import 'theme';
+
+s {
+  text-decoration: none;
+}
+
+.user-detail-container {
+  max-width: 50%;
+}
+
+li {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  white-space: nowrap;
+  line-height: 1.43;
+  margin-bottom: 7px;
+  span {
+    padding-left: 5px;
+    display: inline-block;
+    vertical-align: middle;
+  }
+  svg {
+    flex-grow: 1;
+    height: 12px;
+  }
+}
+
+

--- a/frontend/src/stylesheets/user.scss
+++ b/frontend/src/stylesheets/user.scss
@@ -6,24 +6,29 @@ s {
 
 .user-detail-container {
   max-width: 50%;
+  padding-top: 10px;
+  padding-left: 20px;
 }
 
-li {
+.user-stats-li {
   display: flex;
   align-items: center;
   width: 100%;
   white-space: nowrap;
   line-height: 1.43;
   margin-bottom: 7px;
+  s {
+    padding-right: 5px;
+  }
   span {
     padding-left: 5px;
     display: inline-block;
     vertical-align: middle;
   }
-  svg {
-    flex-grow: 1;
-    height: 12px;
-  }
 }
 
+.rc-progress-line {
+  width: 200px;
+  height: 12px;
+}
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -9934,6 +9934,14 @@ rc-animate@2.x:
     rc-util "^4.8.0"
     react-lifecycles-compat "^3.0.4"
 
+rc-progress@^2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/rc-progress/-/rc-progress-2.5.2.tgz#ab01ba4e5d2fa36fc9f6f058b10b720e7315560c"
+  integrity sha512-ajI+MJkbBz9zYDuE9GQsY5gsyqPF7HFioZEDZ9Fmc+ebNZoiSeSJsTJImPFCg0dW/5WiRGUy2F69SX1aPtSJgA==
+  dependencies:
+    babel-runtime "6.x"
+    prop-types "^15.5.8"
+
 rc-tooltip@3.7.3:
   version "3.7.3"
   resolved "https://registry.yarnpkg.com/rc-tooltip/-/rc-tooltip-3.7.3.tgz#280aec6afcaa44e8dff0480fbaff9e87fc00aecc"

--- a/routes/index.js
+++ b/routes/index.js
@@ -9,3 +9,4 @@ router.get('/', function(req, res, next) {
 router.get('/favicon.ico', (req, res) => res.status(204));
 
 module.exports = router;
+


### PR DESCRIPTION
User rendering was broken when 'exp' for users was renamed to 'experience'
so the conditional to check if user data was retrieved no longer functioned
properly. The user bar was changed to use the `rc-progress` node package,
this allows for easier styling and less setup