### PR TITLE
Switch render order of session forms

### DIFF
--- a/frontend/src/components/splash/session/session.jsx
+++ b/frontend/src/components/splash/session/session.jsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import SessionForm from './session_form';
 
 export default (props) => {
-  const [formType, setFormType] = useState("signup");
+  const [formType, setFormType] = useState("login");
 
   const changeForm = (type) => {
     return (e) => {


### PR DESCRIPTION
Login, including guest login, are now displayed initially on the splash